### PR TITLE
Making python3 explicit.

### DIFF
--- a/nodes/joy_to_helm.py
+++ b/nodes/joy_to_helm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import rospy
 from sensor_msgs.msg import Joy


### PR DESCRIPTION
Making python3 explicit in shebang and removing `from __future__` and `from builtins` imports from `.py` files.

The reasons for this are...

1. For our use-case we are using ROS-Noetic (Python 3) with older code that is Python 2, so need to be explicit with the interpreter. 
2. Noetic is exclusively Python 3, so including the imports can be confusing.